### PR TITLE
playit-agent: install playitd, add brew services support, fix socket path

### DIFF
--- a/Formula/playit-agent.rb
+++ b/Formula/playit-agent.rb
@@ -39,6 +39,16 @@ class PlayitAgent < Formula
     working_dir var
   end
 
+  def caveats
+    <<~EOS
+      To start the playit daemon:
+        brew services start #{name}
+
+      After the service is running, run:
+        #{opt_bin}/playit setup
+    EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/playit version")
   end

--- a/Formula/playit-agent.rb
+++ b/Formula/playit-agent.rb
@@ -26,11 +26,13 @@ class PlayitAgent < Formula
     system "cargo", "install", *std_cargo_args(path: "packages/playit-cli")
     system "cargo", "install", *std_cargo_args(path: "packages/playitd")
     bin.install_symlink "playit-cli" => "playit"
+
+    (etc/"playit").mkpath
   end
 
   service do
     run [opt_bin/"playitd",
-         "--secret-path", var/"playit/playit.toml",
+         "--secret-path", etc/"playit/playit.toml",
          "--log-path", var/"log/playitd.log"]
     run_type :immediate
     keep_alive true
@@ -46,6 +48,9 @@ class PlayitAgent < Formula
 
       After the service is running, run:
         #{opt_bin}/playit setup
+
+      The secret key is stored in:
+        #{etc}/playit/playit.toml
     EOS
   end
 


### PR DESCRIPTION
This is a revision bump for playit-agent 1.0.2.

**Changes:**
- Install `playitd` daemon alongside `playit-cli` (both required since playit-cli depends on playitd via IPC for all operations)
- Patch compiled-in default socket path from `/var/run/playitd.sock` to `#{var}/run/playitd.sock` (user-writable, no root needed)
- Add `service do` block for `brew services` support on Linux
- Bump revision `1` to trigger rebuild with new binaries

**Usage after install:**
```
brew services start playit-agent
playit setup
```