### PR TITLE
docker-credential-helper 0.9.7 (new formula)

### DIFF
--- a/Formula/docker-credential-helper.rb
+++ b/Formula/docker-credential-helper.rb
@@ -1,0 +1,42 @@
+class DockerCredentialHelper < Formula
+  desc "Platform keystore credential helper for Docker"
+  homepage "https://github.com/docker/docker-credential-helpers"
+  url "https://github.com/docker/docker-credential-helpers/archive/refs/tags/v0.9.7.tar.gz"
+  sha256 "28ee1cb4be24f88b9fe76bfd99b7d51af7af618085850c98cf473e520f67c736"
+  license "MIT"
+  head "https://github.com/docker/docker-credential-helpers.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "pkgconf" => :build
+
+  on_linux do
+    depends_on "glib"
+    depends_on "libsecret"
+  end
+
+  def install
+    ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
+
+    if OS.mac?
+      system "make", "osxkeychain"
+      bin.install "bin/build/docker-credential-osxkeychain"
+    else
+      system "make", "secretservice"
+      bin.install "bin/build/docker-credential-secretservice"
+    end
+    system "make", "pass"
+    bin.install "bin/build/docker-credential-pass"
+  end
+
+  test do
+    if OS.mac?
+      run_output = shell_output("#{bin}/docker-credential-osxkeychain", 1)
+      assert_match "Usage: docker-credential-osxkeychain", run_output
+    else
+      run_output = shell_output("#{bin}/docker-credential-secretservice list", 1)
+      assert_match "Cannot autolaunch D-Bus without X11", run_output
+    end
+    run_output = shell_output("#{bin}/docker-credential-pass list")
+    assert_match "{}", run_output
+  end
+end


### PR DESCRIPTION
Adds a new formula for docker-credential-helper.